### PR TITLE
Added support for LazyMapCollections

### DIFF
--- a/Pod/Classes/LayoutConvenience.swift
+++ b/Pod/Classes/LayoutConvenience.swift
@@ -36,7 +36,7 @@ public extension UIView {
         }
     }
     
-    public func addSubviewsWithNoConstraints(subviews: LazyMapCollection<[String: UIView], UIView>) {
+    public func addSubviewsWithNoConstraints<T: UIView>(subviews: LazyMapCollection<[String: T], T>) {
         addSubviewsWithNoConstraints(Array(subviews))
     }
 }

--- a/Pod/Classes/LayoutConvenience.swift
+++ b/Pod/Classes/LayoutConvenience.swift
@@ -35,4 +35,8 @@ public extension UIView {
             addSubview(v)
         }
     }
+    
+    public func addSubviewsWithNoConstraints(subviews: LazyMapCollection<[String: UIView], UIView>) {
+        addSubviewsWithNoConstraints(Array(subviews))
+    }
 }


### PR DESCRIPTION
- You no longer need to cast a LazyMapCollection of views into an Array
for example
```
let views = ["tableView": tableView, "headerView": headerView]

// gross
view.addSubviewsWithNoConstraints(Array(views.values)) 

// what now works
view.addSubviewsWithNoConstraints(views.values)