### PR TITLE
Added objc compatible post func

### DIFF
--- a/Pod/Classes/NotificationConvenience.swift
+++ b/Pod/Classes/NotificationConvenience.swift
@@ -17,6 +17,13 @@ public extension NotificationCenter {
         }
     }
     
+    // Needed for objc compatibility
+    public func post(notification: Notification) -> Void {
+        DispatchQueue.main.async { [weak self] in
+            self?.post(notification)
+        }
+    }
+    
     public func post(notificationName: Notification.Name, queue: DispatchQueue = DispatchQueue.main, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) -> Void {
         let note = Notification(name: notificationName, object: object, userInfo: userInfo)
         post(notification: note, queue: queue)

--- a/Pod/Classes/NotificationConvenience.swift
+++ b/Pod/Classes/NotificationConvenience.swift
@@ -19,9 +19,7 @@ public extension NotificationCenter {
     
     // Needed for objc compatibility
     public func post(notification: Notification) -> Void {
-        DispatchQueue.main.async { [weak self] in
-            self?.post(notification)
-        }
+        post(notification)
     }
     
     public func post(notificationName: Notification.Name, queue: DispatchQueue = DispatchQueue.main, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) -> Void {


### PR DESCRIPTION
- The newer convenience functions for posting a notification are not compatible with objective-c. Using the old method throws warnings in our projects, which I would like to clean up
- Added a simple post function that does not have any default parameters and uses the main queue by default. 