### PR TITLE
Add main queue default

### DIFF
--- a/Pod/Classes/NotificationConvenience.swift
+++ b/Pod/Classes/NotificationConvenience.swift
@@ -19,7 +19,7 @@ public extension NotificationCenter {
     
     // Needed for objc compatibility
     public func post(notification: Notification) -> Void {
-        post(notification)
+        post(notification: notification)
     }
     
     public func post(notificationName: Notification.Name, queue: DispatchQueue = DispatchQueue.main, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) -> Void {
@@ -29,9 +29,5 @@ public extension NotificationCenter {
     
     public func post(name: String, queue: DispatchQueue = DispatchQueue.main, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) -> Void {
         post(notificationName: Notification.Name(rawValue: name), queue: queue, object: object, userInfo: userInfo)
-    }
-    
-    public func postOnMainQueue(notificationName: Notification.Name, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) {
-        post(notificationName: notificationName, queue: DispatchQueue.main, object: object, userInfo: userInfo)
     }
 }

--- a/Pod/Classes/NotificationConvenience.swift
+++ b/Pod/Classes/NotificationConvenience.swift
@@ -30,4 +30,8 @@ public extension NotificationCenter {
     public func post(name: String, queue: DispatchQueue = DispatchQueue.main, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) -> Void {
         post(notificationName: Notification.Name(rawValue: name), queue: queue, object: object, userInfo: userInfo)
     }
+    
+    public func postOnMainQueue(notificationName: Notification.Name, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) {
+        post(notificationName: notificationName, queue: DispatchQueue.main, object: object, userInfo: userInfo)
+    }
 }

--- a/Pod/Classes/NotificationConvenience.swift
+++ b/Pod/Classes/NotificationConvenience.swift
@@ -19,7 +19,7 @@ public extension NotificationCenter {
     
     // Needed for objc compatibility
     public func post(notification: Notification) -> Void {
-        post(notification: notification)
+        post(notification:notification, queue: DispatchQueue.main)
     }
     
     public func post(notificationName: Notification.Name, queue: DispatchQueue = DispatchQueue.main, object: Any? = nil, userInfo: [AnyHashable: Any]? = nil) -> Void {


### PR DESCRIPTION
The purpose of this PR is to add a default main queue method for Notifications, because 
![os_dispatch](https://cloud.githubusercontent.com/assets/4974425/20397456/6b7ef298-acaf-11e6-8a53-8372fc2c7df4.jpeg)
