### PR TITLE
Add `map` function to `Result` type

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - URBNConvenience (2.2)
+  - URBNConvenience (2.2.1)
 
 DEPENDENCIES:
   - URBNConvenience (from `../`)
 
 EXTERNAL SOURCES:
   URBNConvenience:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  URBNConvenience: fa69e412fd7b058f0d391f3f945d6aeee9c57b90
+  URBNConvenience: 415179db7ff624c02b2314aed49aa2ef46b69d80
 
 PODFILE CHECKSUM: 4bfbebbb9fc7a9a90efd38463f9ff637cb17d94e
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/Example/URBNConvenience.xcodeproj/project.pbxproj
+++ b/Example/URBNConvenience.xcodeproj/project.pbxproj
@@ -508,7 +508,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		20959AED760FBBB7C34411A8 /* [CP] Copy Pods Resources */ = {
@@ -538,7 +538,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		831E3E0E487684E70B605A48 /* [CP] Embed Pods Frameworks */ = {
@@ -598,7 +598,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		BFAB2ADB953A0079BEDE0B67 /* [CP] Copy Pods Resources */ = {
@@ -628,7 +628,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		DD1518742C4CB6B5BDB05ACB /* [CP] Embed Pods Frameworks */ = {

--- a/Pod/Classes/ResultType.swift
+++ b/Pod/Classes/ResultType.swift
@@ -121,3 +121,38 @@ public func ==<T>(lhs: Result<T>, rhs: Result<T>) -> Bool {
     default: return false
     }
 }
+
+// MARK: - Map
+extension Result {
+    
+    /// Allow us to transform values in the result type
+    ///
+    /// - Parameter transform: function to transform one value to another
+    /// - Returns: a result with the new value type
+    public func map<U>(_ transform: (Value?) throws -> U?) -> Result<U> {
+        switch self {
+        case .failure(let error):
+            return Result<U>(error)
+        case .success(let value):
+            do {
+                return Result<U>(try transform(value))
+            }
+            catch let error {
+                return Result<U>(error)
+            }
+        }
+    }
+
+    /// Allow us to transform errors in the result type
+    ///
+    /// - Parameter transform: function to transform one error to another
+    /// - Returns: a result with the new error type
+    public func map(_ transform: (Error) -> Error) -> Result<Value> {
+        switch self {
+        case .failure(let error):
+            return Result(transform(error))
+        case .success(let value):
+            return Result(value)
+        }
+    }
+}


### PR DESCRIPTION
This allows us to transform the value or error of a result type easily using the map function and chain them together.

```swift
let intResult = Result(1234) // Result<Int>
let stringResult = intResult.map{ "\($0)" } // Result<String>
```